### PR TITLE
Add support for custom fields on checkout

### DIFF
--- a/priv/translations/template/mod_paysub.pot
+++ b/priv/translations/template/mod_paysub.pot
@@ -245,7 +245,7 @@ msgid ""
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:123
+#: zotonic_mod_paysub/src/mod_paysub.erl:156
 msgid ""
 "Data will be sent to Stripe."
 msgstr ""
@@ -604,7 +604,7 @@ msgid ""
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:456
+#: zotonic_mod_paysub/src/mod_paysub.erl:489
 msgid ""
 "Payment status"
 msgstr ""
@@ -623,31 +623,31 @@ msgid ""
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:422
+#: zotonic_mod_paysub/src/mod_paysub.erl:455
 msgid ""
 "Payments - Dashboard"
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:428
+#: zotonic_mod_paysub/src/mod_paysub.erl:461
 msgid ""
 "Payments - Invoices"
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:446
+#: zotonic_mod_paysub/src/mod_paysub.erl:479
 msgid ""
 "Payments - Payments"
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:440
+#: zotonic_mod_paysub/src/mod_paysub.erl:473
 msgid ""
 "Payments - Products"
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:434
+#: zotonic_mod_paysub/src/mod_paysub.erl:467
 msgid ""
 "Payments - Subscriptions"
 msgstr ""
@@ -741,7 +741,7 @@ msgid ""
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:152
+#: zotonic_mod_paysub/src/mod_paysub.erl:185
 msgid ""
 "Redirecting..."
 msgstr ""
@@ -806,28 +806,28 @@ msgid ""
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:109
+#: zotonic_mod_paysub/src/mod_paysub.erl:142
 msgid ""
 "Sorry, can't create a customer for this PSP."
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:125
+#: zotonic_mod_paysub/src/mod_paysub.erl:158
 msgid ""
 "Sorry, can't find the customer for this PSP."
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:90
-#: zotonic_mod_paysub/src/mod_paysub.erl:93
+#: zotonic_mod_paysub/src/mod_paysub.erl:123
+#: zotonic_mod_paysub/src/mod_paysub.erl:126
 msgid ""
 "Sorry, can't redirect to the customer portal."
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:163
-#: zotonic_mod_paysub/src/mod_paysub.erl:174
-#: zotonic_mod_paysub/src/mod_paysub.erl:181
+#: zotonic_mod_paysub/src/mod_paysub.erl:196
+#: zotonic_mod_paysub/src/mod_paysub.erl:207
+#: zotonic_mod_paysub/src/mod_paysub.erl:214
 msgid ""
 "Sorry, something goes wrong, try again later."
 msgstr ""
@@ -842,19 +842,19 @@ msgid ""
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:106
+#: zotonic_mod_paysub/src/mod_paysub.erl:139
 msgid ""
 "Sorry, something went wrong."
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:192
+#: zotonic_mod_paysub/src/mod_paysub.erl:225
 msgid ""
 "Sorry, the password has already been reset."
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:202
+#: zotonic_mod_paysub/src/mod_paysub.erl:235
 msgid ""
 "Sorry, this checkout could not be fetched."
 msgstr ""
@@ -866,13 +866,13 @@ msgid ""
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:112
+#: zotonic_mod_paysub/src/mod_paysub.erl:145
 msgid ""
 "Sorry, you are not allowed to create a customer for this PSP."
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:128
+#: zotonic_mod_paysub/src/mod_paysub.erl:161
 msgid ""
 "Sorry, you are not allowed to update customer for this PSP."
 msgstr ""
@@ -962,7 +962,7 @@ msgid ""
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:228
+#: zotonic_mod_paysub/src/mod_paysub.erl:261
 msgid ""
 "The user is not a main contact of the organization."
 msgstr ""
@@ -1104,15 +1104,15 @@ msgid ""
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:231
+#: zotonic_mod_paysub/src/mod_paysub.erl:264
 msgid ""
 "You are not allowed to do this."
 msgstr ""
 ""
 
-#: zotonic_mod_paysub/src/mod_paysub.erl:80
-#: zotonic_mod_paysub/src/mod_paysub.erl:215
-#: zotonic_mod_paysub/src/mod_paysub.erl:240
+#: zotonic_mod_paysub/src/mod_paysub.erl:113
+#: zotonic_mod_paysub/src/mod_paysub.erl:248
+#: zotonic_mod_paysub/src/mod_paysub.erl:273
 msgid ""
 "You are not allowed to edit products."
 msgstr ""

--- a/src/controllers/controller_paysub_stripe_webhook.erl
+++ b/src/controllers/controller_paysub_stripe_webhook.erl
@@ -2,7 +2,7 @@
 %% @doc Handle stripe callbacks for subscription and payment events
 %% @end
 
-%% Copyright 2022-2026 Marc Worrrell
+%% Copyright 2022-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/controllers/controller_paysub_stripe_webhook.erl
+++ b/src/controllers/controller_paysub_stripe_webhook.erl
@@ -1,8 +1,8 @@
-%% @copyright 2022 Marc Worrell
+%% @copyright 2022-2026 Marc Worrell
 %% @doc Handle stripe callbacks for subscription and payment events
 %% @end
 
-%% Copyright 2022 Marc Worrrell
+%% Copyright 2022-2026 Marc Worrrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
     process/4
 ]).
 
--define(TIMESTAMP_TOLERANCE, 10).
+-define(TIMESTAMP_TOLERANCE, 300).
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 

--- a/src/mod_paysub.erl
+++ b/src/mod_paysub.erl
@@ -1,9 +1,9 @@
 %% @author Marc Worrell <marc@worrell.nl>
-%% @copyright 2022-2024 Marc Worrell
+%% @copyright 2022-2026 Marc Worrell
 %% @doc Subscriptions and payments for members using Stripe and other PSPs
 %% @end
 
-%% Copyright 2022-2024 Marc Worrell
+%% Copyright 2022-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -25,6 +25,39 @@
 -mod_depends([ mod_authentication, mod_l10n ]).
 -mod_schema(13).
 -mod_prio(500).
+
+-mod_config([
+        #{
+            key => stripe_api_key,
+            type => string,
+            default => <<>>,
+            description => "The API key for Stripe. This is required to use Stripe as a payment service provider."
+        },
+        #{
+            key => stripe_webhook_secret,
+            type => string,
+            default => <<>>,
+            description => "The webhook secret for Stripe. This is required to verify the authenticity of webhook events from Stripe."
+        },
+        #{
+            key => is_unpaid_access,
+            type => boolean,
+            default => false,
+            description => "If set to true, users with incomplete_expired and unpaid subscriptions will have access to the site. "
+                           "If set to false, users with unpaid subscriptions will not have access to the site. This can be useful "
+                           "if you want to allow users to access the site while they are in the process of renewing their "
+                           "subscription or if you want to give users a grace period after their subscription has expired."
+        },
+        #{
+            key => is_no_customer_sync,
+            type => boolean,
+            default => false,
+            description => "If set to true, the customer data will not be synced from the PSP to the resource. This means that "
+                           "changes to the customer data at the PSP will not be reflected in the resource. This can be useful if "
+                           "you want to manage the customer data manually or if you have a large number of customers and want to "
+                           "avoid syncing all data."
+        }
+    ]).
 
 -author("Marc Worrell <marc@worrell.nl>").
 

--- a/src/models/m_paysub.erl
+++ b/src/models/m_paysub.erl
@@ -27,7 +27,7 @@
 %% a customer, you may choose to reopen and pay their closed invoices.
 
 
-%% Copyright 2022-2026 Marc Worrrell
+%% Copyright 2022-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/models/m_paysub.erl
+++ b/src/models/m_paysub.erl
@@ -1,4 +1,4 @@
-%% @copyright 2022-2025 Marc Worrell
+%% @copyright 2022-2026 Marc Worrell
 %% @doc Model for paid subscriptions
 %% @end
 
@@ -27,7 +27,7 @@
 %% a customer, you may choose to reopen and pay their closed invoices.
 
 
-%% Copyright 2022-2024 Marc Worrrell
+%% Copyright 2022-2026 Marc Worrrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -1419,7 +1419,7 @@ user_payments(UserId0, Context) ->
 checkout_status(undefined, _Context) ->
     {error, enoent};
 checkout_status(CheckoutNr, Context) ->
-    Result = case z_db:qmap_props_row("
+    Result = case z_db:qmap_row("
         select status,
                payment_status,
                rsc_id,
@@ -1436,8 +1436,7 @@ checkout_status(CheckoutNr, Context) ->
                 <<"requestor_id">> := RequestorId,
                 <<"survey_id">> := SurveyId,
                 <<"survey_answer_id">> := SurveyResultId,
-                <<"is_use_maincontact">> := IsUseMainContact,
-                <<"args">> := Args
+                <<"props_json">> := Props
             } = CheckoutStatus} ->
             S = status(CheckoutStatus),
             UserId = case RequestorId of
@@ -1449,11 +1448,13 @@ checkout_status(CheckoutNr, Context) ->
                 <<"requestor_id">> => RequestorId,
                 <<"user_id">> => UserId,
                 <<"survey_id">> => SurveyId,
-                <<"survey_answer_id">> => SurveyResultId,
-                <<"is_use_maincontact">> => IsUseMainContact,
-                <<"args">> => Args
+                <<"survey_answer_id">> => SurveyResultId
             },
-            {ok, S1};
+            S2 = case is_map(Props) of
+                true -> maps:merge(Props, S1);
+                false -> S1
+            end,
+            {ok, S2};
         {error, _} = Error ->
             Error
     end,
@@ -1921,10 +1922,8 @@ sync_payment_trans(PSP, #{ psp_payment_id := PaymentId } = Payment, Context) ->
     of
         undefined ->
             Payment1 = Payment#{ psp => PSP },
-            case z_db:insert(paysub_payment, Payment1, Context) of
-                {ok, _} ->
-                    ok;
-                {error, #error{ codename = unique_violation }} ->
+            case z_db:insert(paysub_payment, Payment1, [{conflict, ignore}], Context) of
+                {ok, undefined} ->
                     Id = z_db:q1("
                         select id
                         from paysub_payment
@@ -1933,8 +1932,10 @@ sync_payment_trans(PSP, #{ psp_payment_id := PaymentId } = Payment, Context) ->
                         for update",
                         [ PSP, PaymentId ],
                         Context),
-                {ok, _} = z_db:update(paysub_payment, Id, Payment, Context),
-                ok
+                    {ok, _} = z_db:update(paysub_payment, Id, Payment, Context),
+                    ok;
+                {ok, _} ->
+                    ok
             end;
         Id ->
             {ok, _} = z_db:update(paysub_payment, Id, Payment, Context),
@@ -2202,10 +2203,9 @@ sync_customer_trans(PSP, #{ psp_customer_id := PspCustId } = Cust, Context) ->
         Context)
     of
         undefined ->
-            case z_db:insert(paysub_customer, Cust, Context) of
-                {ok, _} ->
-                    {ok, new};
-                {error, #error{ codename = unique_violation }} ->
+
+            case z_db:insert(paysub_customer, Cust, [{conflict, ignore}], Context) of
+                {ok, undefined} ->
                     Id = z_db:q1("
                         select id
                         from paysub_customer
@@ -2216,6 +2216,8 @@ sync_customer_trans(PSP, #{ psp_customer_id := PspCustId } = Cust, Context) ->
                         Context),
                     sync_customer_trans_1(Id, PSP, PspCustId, Cust, Context),
                     {ok, update};
+                {ok, _} ->
+                    {ok, new};
                 {error, _} = Error ->
                     Error
             end;
@@ -2732,10 +2734,8 @@ sync_invoice_trans(PSP, #{ psp_invoice_id := InvId } = Inv, Context) ->
     of
         undefined ->
             Inv1 = Inv#{ psp => PSP },
-            case z_db:insert(paysub_invoice, Inv1, Context) of
-                {ok, _} ->
-                    ok;
-                {error, #error{ codename = unique_violation }} ->
+            case z_db:insert(paysub_invoice, Inv1, [{conflict, ignore}], Context) of
+                {ok, undefined} ->
                     Id = z_db:q1("
                         select id
                         from paysub_invoice
@@ -2745,6 +2745,8 @@ sync_invoice_trans(PSP, #{ psp_invoice_id := InvId } = Inv, Context) ->
                         [ PSP, InvId ],
                         Context),
                     {ok, _} = z_db:update(paysub_invoice, Id, Inv, Context),
+                    ok;
+                {ok, _} ->
                     ok;
                 {error, _} = Error ->
                     Error

--- a/src/models/m_paysub_search.erl
+++ b/src/models/m_paysub_search.erl
@@ -1,3 +1,22 @@
+%% @copyright 2022-2026 Marc Worrell
+%% @doc Search payments, add extra query terms for subscribers and perform queries
+%% for the observer_search_query in mod_paysub.erl
+%% @end
+
+%% Copyright 2022-2026 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(m_paysub_search).
 
 -export([

--- a/src/support/paysub_export_subscriptions.erl
+++ b/src/support/paysub_export_subscriptions.erl
@@ -1,4 +1,20 @@
+%% @copyright 2022-2026 Marc Worrell
 %% @doc Export all subscriptions and their last invoice.
+%% @end
+
+%% Copyright 2022-2026 Marc Worrell
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
 
 -module(paysub_export_subscriptions).
 

--- a/src/support/paysub_stripe.erl
+++ b/src/support/paysub_stripe.erl
@@ -560,13 +560,13 @@ maybe_add_custom_fields(Payload, Args) ->
                 fun
                     (Name) when is_binary(Name); is_atom(Name) ->
                         #{
-                            <<"key">> => Name,
-                            <<"label">> => #{
-                                <<"type">> => <<"custom">>,
-                                <<"custom">> => Name
+                            key => Name,
+                            label => #{
+                                type => <<"custom">>,
+                                custom => Name
                             },
-                            <<"type">> => <<"text">>,
-                            <<"optional">> => true
+                            type => <<"text">>,
+                            optional => true
                         };
                     (#{ <<"name">> := Name, <<"options">> := Options } = F) ->
                         Label = maps:get(<<"label">>, F, Name),

--- a/src/support/paysub_stripe.erl
+++ b/src/support/paysub_stripe.erl
@@ -570,19 +570,28 @@ maybe_add_custom_fields(Payload, Args) ->
                         };
                     (#{ <<"name">> := Name, <<"options">> := Options } = F) ->
                         Label = maps:get(<<"label">>, F, Name),
-                        Options1 = lists:map(
+                        Options1 = lists:filtermap(
                             fun
-                                (Option) when is_binary(Option) ->
-                                    #{
-                                        label => Option,
-                                        value => Option
-                                    };
+                                (Option) when is_binary(Option); is_atom(Option) ->
+                                    OptBin = z_convert:to_binary(Option),
+                                    {true, #{
+                                        label => OptBin,
+                                        value => OptBin
+                                    }};
                                 (#{ <<"value">> := Value } = Opt) ->
                                     OptLabel = maps:get(<<"label">>, Opt, Value),
-                                    #{
+                                    {true, #{
                                         label => OptLabel,
                                         value => Value
-                                    }
+                                    }};
+                                (#{ value := Value } = Opt) ->
+                                    OptLabel = maps:get(label, Opt, Value),
+                                    {true, #{
+                                        label => z_convert:to_binary(OptLabel),
+                                        value => z_convert:to_binary(Value)
+                                    }};
+                                (_) ->
+                                    false
                             end,
                             Options),
                         IsRequired = z_convert:to_bool(maps:get(<<"is_required">>, F, false)),

--- a/src/support/paysub_stripe.erl
+++ b/src/support/paysub_stripe.erl
@@ -1,8 +1,8 @@
-%% @copyright 2022-2024 Marc Worrell
+%% @copyright 2022-2026 Marc Worrell
 %% @doc Stripe support for payments and subscriptions.
 %% @end
 
-%% Copyright 2022-2024 Marc Worrrell
+%% Copyright 2022-2026 Marc Worrrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -381,17 +381,18 @@ checkout_session_create(Args, Context) ->
                         customer_email => Email
                     }
             end,
+            Payload3 = maybe_add_custom_fields(Payload2, Args),
             IsBillingAddressCollection = z_convert:to_bool(proplists:get_value(is_billing_address_collection, Args, true)),
             BaseSub = case z_convert:to_integer(proplists:get_value(trial_days, Args, 0)) of
                 N when is_integer(N), N >= 1 -> #{ trial_period_days => N };
                 _ -> #{}
             end,
-            Payload3 = case m_paysub:get_customer(stripe, SubscriberId, Context) of
+            Payload4 = case m_paysub:get_customer(stripe, SubscriberId, Context) of
                 {ok, #{
                     <<"psp_customer_id">> := CustId
                 }} when is_binary(CustId) ->
                     % Only customer or customer_email can be used.
-                    PE1 = maps:remove(customer_email, Payload2#{
+                    PE1 = maps:remove(customer_email, Payload3#{
                         customer => CustId,
                         customer_update => #{
                             address => auto,
@@ -428,17 +429,17 @@ checkout_session_create(Args, Context) ->
                             }
                     end;
                 {error, enoent} when is_integer(SubscriberId) ->
-                    PE1 = case Payload2 of
+                    PE1 = case Payload3 of
                         #{
                             customer_email := _
                         } ->
-                            Payload2;
+                            Payload3;
                         _ ->
                             case m_rsc:p_no_acl(SubscriberId, email_raw, Context) of
                                 undefined ->
-                                    Payload2;
+                                    Payload3;
                                 UserEmail ->
-                                    Payload2#{
+                                    Payload3#{
                                         customer_email => UserEmail
                                     }
                             end
@@ -474,7 +475,7 @@ checkout_session_create(Args, Context) ->
                             }
                     end;
                 {error, enoent} when SubscriberId =:= undefined, Mode =:= payment ->
-                    PE1 = Payload2#{
+                    PE1 = Payload3#{
                         customer_creation => if_required,
                         billing_address_collection => auto,
                         invoice_creation => #{
@@ -487,7 +488,7 @@ checkout_session_create(Args, Context) ->
                     },
                     maybe_add_consent_collection(PE1, Args, true);
                 {error, enoent} when SubscriberId =:= undefined, Mode =:= subscription ->
-                    PE1 = Payload2#{
+                    PE1 = Payload3#{
                             billing_address_collection =>
                                 case IsBillingAddressCollection of
                                     true -> required;
@@ -497,14 +498,14 @@ checkout_session_create(Args, Context) ->
                         },
                     maybe_add_consent_collection(PE1, Args, true)
             end,
-            Payload4 = case z_convert:to_binary(proplists:get_value(currency, Args)) of
-                <<>> -> Payload3;
+            Payload5 = case z_convert:to_binary(proplists:get_value(currency, Args)) of
+                <<>> -> Payload4;
                 RequestedCurrency ->
-                    Payload3#{
+                    Payload4#{
                         currency => RequestedCurrency
                     }
             end,
-            case paysub_stripe_api:fetch(post, [ "checkout", "sessions" ], Payload4, Context) of
+            case paysub_stripe_api:fetch(post, [ "checkout", "sessions" ], Payload5, Context) of
                 {ok, #{
                     <<"url">> := Url,
                     <<"id">> := PspCheckoutId,
@@ -548,6 +549,73 @@ checkout_session_create(Args, Context) ->
                 args => Args
             }),
             Error
+    end.
+
+maybe_add_custom_fields(Payload, Args) ->
+    case proplists:get_value(custom_props, Args) of
+        undefined ->
+            Payload;
+        CustomFields when is_list(CustomFields) ->
+            Custom = lists:map(
+                fun
+                    (Name) when is_binary(Name); is_atom(Name) ->
+                        #{
+                            <<"key">> => Name,
+                            <<"label">> => #{
+                                <<"type">> => <<"custom">>,
+                                <<"custom">> => Name
+                            },
+                            <<"type">> => <<"text">>,
+                            <<"optional">> => true
+                        };
+                    (#{ <<"name">> := Name, <<"options">> := Options } = F) ->
+                        Label = maps:get(<<"label">>, F, Name),
+                        Options1 = lists:map(
+                            fun
+                                (Option) when is_binary(Option) ->
+                                    #{
+                                        label => Option,
+                                        value => Option
+                                    };
+                                (#{ <<"value">> := Value } = Opt) ->
+                                    Label = maps:get(<<"label">>, Opt, Value),
+                                    #{
+                                        label => Label,
+                                        value => Value
+                                    }
+                            end,
+                            Options),
+                        IsRequired = z_convert:to_bool(maps:get(<<"is_required">>, F, false)),
+                        #{
+                            key => Name,
+                            label => #{
+                                type => <<"custom">>,
+                                custom => Label
+                            },
+                            type => <<"dropdown">>,
+                            optional => not IsRequired,
+                            dropdown => #{
+                                options => Options1
+                            }
+                        };
+                    (#{ <<"name">> := Name } = F) ->
+                        Label = maps:get(<<"label">>, F, Name),
+                        Type = maps:get(<<"type">>, F, <<"text">>),
+                        IsRequired = z_convert:to_bool(maps:get(<<"is_required">>, F, false)),
+                        #{
+                            key => Name,
+                            label => #{
+                                type => <<"custom">>,
+                                custom => Label
+                            },
+                            type => Type,
+                            optional => not IsRequired
+                        }
+                end,
+                CustomFields),
+            Payload#{
+                custom_fields => Custom
+            }
     end.
 
 maybe_add_consent_collection(Payload, Args, Default) ->
@@ -676,10 +744,43 @@ checkout_session_sync(Session, Context) ->
         status => Status,
         payment_status => PaymentStatus,
         currency => z_string:to_upper(Currency),
-        amount => Amount
+        amount => Amount,
+        custom_props => extract_custom_fields(Session)
     },
     m_paysub:checkout_update(stripe, CheckoutNr, Update, Context),
     ok.
+
+extract_custom_fields(#{ <<"custom_fields">> := Fields }) when is_list(Fields) ->
+    lists:foldl(
+        fun
+            (#{
+                <<"key">> := Key,
+                <<"text">> := #{
+                    <<"value">> := Value
+                }
+            }, Acc) when is_binary(Value), Value =/= <<>> ->
+                Acc#{ Key => Value };
+            (#{
+                <<"key">> := Key,
+                <<"dropdown">> := #{
+                    <<"value">> := Value
+                }
+            }, Acc) when is_binary(Value), Value =/= <<>> ->
+                Acc#{ Key => Value };
+            (#{
+                <<"key">> := Key,
+                <<"numeric">> := #{
+                    <<"value">> := Value
+                }
+            }, Acc) when is_binary(Value), Value =/= <<>> ->
+                Acc#{ Key => z_convert:to_integer(Value) };
+            (_, Acc) ->
+                Acc
+        end,
+        #{},
+        Fields);
+extract_custom_fields(#{}) ->
+    #{}.
 
 
 %% @doc Called on by controller_subscription_stripe_redirect on a successful checkout

--- a/src/support/paysub_stripe.erl
+++ b/src/support/paysub_stripe.erl
@@ -556,10 +556,10 @@ maybe_add_custom_fields(Payload, Args) ->
         undefined ->
             Payload;
         CustomFields when is_list(CustomFields) ->
-            Custom = lists:map(
+            Custom = lists:filtermap(
                 fun
                     (Name) when is_binary(Name); is_atom(Name) ->
-                        #{
+                        {true, #{
                             key => Name,
                             label => #{
                                 type => <<"custom">>,
@@ -567,25 +567,34 @@ maybe_add_custom_fields(Payload, Args) ->
                             },
                             type => <<"text">>,
                             optional => true
-                        };
+                        }};
                     (#{ <<"name">> := Name, <<"options">> := Options } = F) ->
                         Label = maps:get(<<"label">>, F, Name),
                         IsRequired = z_convert:to_bool(maps:get(<<"is_required">>, F, false)),
-                        custom_field_options(Name, Label, IsRequired, Options);
+                        {true, custom_field_options(Name, Label, IsRequired, Options)};
                     (#{ name := Name, options := Options } = F) ->
                         Label = maps:get(label, F, Name),
                         IsRequired = z_convert:to_bool(maps:get(is_required, F, false)),
-                        custom_field_options(Name, Label, IsRequired, Options);
+                        {true, custom_field_options(Name, Label, IsRequired, Options)};
                     (#{ <<"name">> := Name } = F) ->
                         Label = maps:get(<<"label">>, F, Name),
                         Type = maps:get(<<"type">>, F, <<"text">>),
                         IsRequired = z_convert:to_bool(maps:get(<<"is_required">>, F, false)),
-                        custom_field_type(Name, Label, IsRequired, Type);
+                        {true, custom_field_type(Name, Label, IsRequired, Type)};
                     (#{ name := Name } = F) ->
                         Label = maps:get(label, F, Name),
                         Type = maps:get(type, F, <<"text">>),
                         IsRequired = z_convert:to_bool(maps:get(is_required, F, false)),
-                        custom_field_type(Name, Label, IsRequired, Type)
+                        {true, custom_field_type(Name, Label, IsRequired, Type)};
+                    (F) ->
+                        ?LOG_ERROR(#{
+                            in => zotonic_mod_paysub,
+                            text => <<"Invalid custom field definition, skipping">>,
+                            result => error,
+                            reason => no_name,
+                            field => F
+                        }),
+                        false
                 end,
                 CustomFields),
             Payload#{

--- a/src/support/paysub_stripe.erl
+++ b/src/support/paysub_stripe.erl
@@ -578,9 +578,9 @@ maybe_add_custom_fields(Payload, Args) ->
                                         value => Option
                                     };
                                 (#{ <<"value">> := Value } = Opt) ->
-                                    Label = maps:get(<<"label">>, Opt, Value),
+                                    OptLabel = maps:get(<<"label">>, Opt, Value),
                                     #{
-                                        label => Label,
+                                        label => OptLabel,
                                         value => Value
                                     }
                             end,

--- a/src/support/paysub_stripe.erl
+++ b/src/support/paysub_stripe.erl
@@ -2,7 +2,7 @@
 %% @doc Stripe support for payments and subscriptions.
 %% @end
 
-%% Copyright 2022-2026 Marc Worrrell
+%% Copyright 2022-2026 Marc Worrell
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/support/paysub_stripe.erl
+++ b/src/support/paysub_stripe.erl
@@ -570,62 +570,79 @@ maybe_add_custom_fields(Payload, Args) ->
                         };
                     (#{ <<"name">> := Name, <<"options">> := Options } = F) ->
                         Label = maps:get(<<"label">>, F, Name),
-                        Options1 = lists:filtermap(
-                            fun
-                                (Option) when is_binary(Option); is_atom(Option) ->
-                                    OptBin = z_convert:to_binary(Option),
-                                    {true, #{
-                                        label => OptBin,
-                                        value => OptBin
-                                    }};
-                                (#{ <<"value">> := Value } = Opt) ->
-                                    OptLabel = maps:get(<<"label">>, Opt, Value),
-                                    {true, #{
-                                        label => OptLabel,
-                                        value => Value
-                                    }};
-                                (#{ value := Value } = Opt) ->
-                                    OptLabel = maps:get(label, Opt, Value),
-                                    {true, #{
-                                        label => z_convert:to_binary(OptLabel),
-                                        value => z_convert:to_binary(Value)
-                                    }};
-                                (_) ->
-                                    false
-                            end,
-                            Options),
                         IsRequired = z_convert:to_bool(maps:get(<<"is_required">>, F, false)),
-                        #{
-                            key => Name,
-                            label => #{
-                                type => <<"custom">>,
-                                custom => Label
-                            },
-                            type => <<"dropdown">>,
-                            optional => not IsRequired,
-                            dropdown => #{
-                                options => Options1
-                            }
-                        };
+                        custom_field_options(Name, Label, IsRequired, Options);
+                    (#{ name := Name, options := Options } = F) ->
+                        Label = maps:get(label, F, Name),
+                        IsRequired = z_convert:to_bool(maps:get(is_required, F, false)),
+                        custom_field_options(Name, Label, IsRequired, Options);
                     (#{ <<"name">> := Name } = F) ->
                         Label = maps:get(<<"label">>, F, Name),
                         Type = maps:get(<<"type">>, F, <<"text">>),
                         IsRequired = z_convert:to_bool(maps:get(<<"is_required">>, F, false)),
-                        #{
-                            key => Name,
-                            label => #{
-                                type => <<"custom">>,
-                                custom => Label
-                            },
-                            type => Type,
-                            optional => not IsRequired
-                        }
+                        custom_field_type(Name, Label, IsRequired, Type);
+                    (#{ name := Name } = F) ->
+                        Label = maps:get(label, F, Name),
+                        Type = maps:get(type, F, <<"text">>),
+                        IsRequired = z_convert:to_bool(maps:get(is_required, F, false)),
+                        custom_field_type(Name, Label, IsRequired, Type)
                 end,
                 CustomFields),
             Payload#{
                 custom_fields => Custom
             }
     end.
+
+
+custom_field_type(Name, Label, IsRequired, Type) ->
+    #{
+        key => Name,
+        label => #{
+            type => <<"custom">>,
+            custom => Label
+        },
+        type => Type,
+        optional => not IsRequired
+    }.
+
+custom_field_options(Name, Label, IsRequired, Options) ->
+    Options1 = lists:filtermap(
+        fun
+            (Option) when is_binary(Option); is_atom(Option) ->
+                OptBin = z_convert:to_binary(Option),
+                {true, #{
+                    label => OptBin,
+                    value => OptBin
+                }};
+            (#{ <<"value">> := Value } = Opt) ->
+                OptLabel = maps:get(<<"label">>, Opt, Value),
+                {true, #{
+                    label => OptLabel,
+                    value => Value
+                }};
+            (#{ value := Value } = Opt) ->
+                OptLabel = maps:get(label, Opt, Value),
+                {true, #{
+                    label => z_convert:to_binary(OptLabel),
+                    value => z_convert:to_binary(Value)
+                }};
+            (_) ->
+                false
+        end,
+        Options),
+    #{
+        key => Name,
+        label => #{
+            type => <<"custom">>,
+            custom => Label
+        },
+        type => <<"dropdown">>,
+        optional => not IsRequired,
+        dropdown => #{
+            options => Options1
+        }
+    }.
+
 
 maybe_add_consent_collection(Payload, Args, Default) ->
     case proplists:get_value(consent_collection, Args) of


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the paid subscriptions (mod_paysub) module, especially around Stripe integration, database syncing, and configuration flexibility. It also adds copyright year updates and some new supporting modules.

**Key changes include:**

### Configuration and Flexibility

* Added new configuration documentation to `mod_paysub` for Stripe API key, Stripe webhook secret, unpaid access behavior, and customer sync control, allowing more flexible deployment and feature toggling.

### Stripe Integration Improvements

* Increased the Stripe webhook timestamp tolerance from 10 to 300 seconds, reducing the chance of legitimate webhook requests being rejected due to clock drift.
* Improved the creation of Stripe checkout sessions to support custom fields and more robust handling of customer email assignment. [[1]](diffhunk://#diff-1c575eb37c214d04f840296495f1d64ea26321d2001bc3f4f58e7419a50fb740R384-R395) [[2]](diffhunk://#diff-1c575eb37c214d04f840296495f1d64ea26321d2001bc3f4f58e7419a50fb740L431-R442)

### Database Sync Robustness

* Updated payment, customer, and invoice syncing logic to use conflict-ignore inserts and handle upserts more cleanly, ensuring idempotency and reducing the risk of duplicate errors during synchronization. [[1]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943L1924-R1926) [[2]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943R1936-R1937) [[3]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943L2205-R2208) [[4]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943R2219-R2220) [[5]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943L2735-R2738) [[6]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943R2749-R2750)
* Improved the `checkout_status/2` function to use a more direct DB query and to merge additional JSON properties from the database into the result, supporting future extensibility. [[1]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943L1422-R1422) [[2]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943L1439-R1439) [[3]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943L1452-R1457)

### Internationalization and Copyright

* Updated translation references in `mod_paysub.pot` to match new line numbers in the source code. [[1]](diffhunk://#diff-e46ea79205522265d79e1e7af7dd07d9286fd2aa6cbce28759d1ffbc9ce7c964L248-R248) [[2]](diffhunk://#diff-e46ea79205522265d79e1e7af7dd07d9286fd2aa6cbce28759d1ffbc9ce7c964L607-R607) [[3]](diffhunk://#diff-e46ea79205522265d79e1e7af7dd07d9286fd2aa6cbce28759d1ffbc9ce7c964L626-R650) [[4]](diffhunk://#diff-e46ea79205522265d79e1e7af7dd07d9286fd2aa6cbce28759d1ffbc9ce7c964L744-R744) [[5]](diffhunk://#diff-e46ea79205522265d79e1e7af7dd07d9286fd2aa6cbce28759d1ffbc9ce7c964L809-R830) [[6]](diffhunk://#diff-e46ea79205522265d79e1e7af7dd07d9286fd2aa6cbce28759d1ffbc9ce7c964L845-R857) [[7]](diffhunk://#diff-e46ea79205522265d79e1e7af7dd07d9286fd2aa6cbce28759d1ffbc9ce7c964L869-R875) [[8]](diffhunk://#diff-e46ea79205522265d79e1e7af7dd07d9286fd2aa6cbce28759d1ffbc9ce7c964L965-R965) [[9]](diffhunk://#diff-e46ea79205522265d79e1e7af7dd07d9286fd2aa6cbce28759d1ffbc9ce7c964L1107-R1115)
* Updated copyright years to 2026 throughout all relevant files. [[1]](diffhunk://#diff-ec23849b82db11082264d0f9cf69c1d723782f68c94d38d7df5e1f9e1f982a3eL1-R5) [[2]](diffhunk://#diff-fb619ef222c2adc80d9912067f2ba1f8d95b3a72b6d57659080168cd10661e52L2-R6) [[3]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943L1-R1) [[4]](diffhunk://#diff-94b60261d312b4b5d8de2a3f15a5a32e40b17e63b0268b45fb1230d7beb2e943L30-R30) [[5]](diffhunk://#diff-1c575eb37c214d04f840296495f1d64ea26321d2001bc3f4f58e7419a50fb740L1-R5)

